### PR TITLE
Updated to make the client work with python[2|3] also added support for local setups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Otherwise all ssl connections are verified by default.
 
 ```python
 import pyeti, json    # json is only used for pretty printing in the examples below 
-api = pyeti.YetiApi("http://localhost:5000/api/",verifySSL=False)
+api = pyeti.YetiApi("http://localhost:5000/api/", verify_ssl=False)
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import pyeti, json    # json is only used for pretty printing in the examples be
 api = pyeti.YetiApi("http://localhost:5000/api/")
 ```
 
-If you are using a self signed cert on your yeti instance you can set the verifySSL flag to false to ignore warnings.
+If you are using a self signed cert on your yeti instance you can set the `verify_ssl` parameter to `True` to false to ignore warnings.
 Otherwise all ssl connections are verified by default.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ import pyeti, json    # json is only used for pretty printing in the examples be
 api = pyeti.YetiApi("http://localhost:5000/api/")
 ```
 
+If you are using a self signed cert on your yeti instance you can set the verifySSL flag to false to ignore warnings.
+Otherwise all ssl connections are verified by default.
+
+```python
+import pyeti, json    # json is only used for pretty printing in the examples below 
+api = pyeti.YetiApi("http://localhost:5000/api/",verifySSL=False)
+
+```
+
+
 ### Adding observables
 
 ```python

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ api = pyeti.YetiApi("http://localhost:5000/api/")
 
 ```python
 results = api.observable_add("google.com", ['google'])
-print json.dumps(results, indent=4, sort_keys=True)
+print(json.dumps(results, indent=4, sort_keys=True))
 {
     "context": [],
     "created": "2017-06-25T17:33:51.735000",
@@ -56,9 +56,9 @@ print json.dumps(results, indent=4, sort_keys=True)
 
 ```python
 results = api.observable_bulk_add(["google.com", "bing.com", "yahoo.com"])
-print len(results)
+print(len(results))
 3
-print json.dumps(results[1], indent=4, sort_keys=True)
+print(json.dumps(results[1], indent=4, sort_keys=True))
 {
     "context": [],
     "created": "2017-06-25T17:39:31.051000",
@@ -80,9 +80,9 @@ print json.dumps(results[1], indent=4, sort_keys=True)
 
 ```python
 results = api.observable_add("google.com")
-print results['id']
+print(results['id'])
 info = api.observable_details(results['id'])
-print json.dumps(info, indent=4, sort_keys=True)
+print(json.dumps(info, indent=4, sort_keys=True))
 {
     "context": [],
     "created": "2017-06-25T17:33:51.735000",
@@ -112,7 +112,7 @@ print json.dumps(info, indent=4, sort_keys=True)
 ```python
 api.observable_add("search-domain.com")
 result = api.observable_search(value="search-dom[a-z]+")
-print json.dumps(result, indent=4, sort_keys=True)
+print(json.dumps(result, indent=4, sort_keys=True))
 [
     {
         "context": [],
@@ -137,7 +137,7 @@ print json.dumps(result, indent=4, sort_keys=True)
 
 ```python
 result = api.observable_file_add("/tmp/hello.txt", tags=['benign'])
-print json.dumps(result, indent=4, sort_keys=True)
+print(json.dumps(result, indent=4, sort_keys=True))
 [
     {
         "context": [],

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ Python bindings for Yeti's API
 
 ## Installation
 
-`$ python setup.py install` should get you started. After this gets a little more maturity, we will submit it to Pypy for usage with `pip`.
+`$ python3 setup.py install` should get you started. After this gets a little more maturity, we will submit it to Pypy for usage with `pip`.
 
 ## Testing
 
 You can run tests from the root directory by running:
 
-    $ pip install nose
-    $ python setup.py test
+    $ pip3 install nose
+    $ python3 setup.py test
     
 **Note that most tests require a full running install of Yeti on localhost:5000**
 
@@ -180,10 +180,8 @@ print(json.dumps(result, indent=4, sort_keys=True))
     }
 ]
 # Get file contents
-api.observable_file_contents(id="594fff86bf365e6270f8914b")
+api.observable_file_contents(objectid="594fff86bf365e6270f8914b")
 'Hello!\n'
-api.observable_file_contents(hash="e134ced312b3511d88943d57ccd70c83") # you can also use any hash computed above
+api.observable_file_contents(filehash="e134ced312b3511d88943d57ccd70c83") # you can also use any hash computed above
 'Hello!\n'
 ```
-
-

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ print(json.dumps(info, indent=4, sort_keys=True))
 
 ```python
 api.observable_add("search-domain.com")
-result = api.observable_search(value="search-dom[a-z]+")
+result = api.observable_search(value="search-dom[a-z]+", regex=True)
 print(json.dumps(result, indent=4, sort_keys=True))
 [
     {

--- a/pyeti/api.py
+++ b/pyeti/api.py
@@ -354,7 +354,7 @@ class YetiApi(object):
             verify=self.verifySSL, **kwargs)
         if method == "GET":
             resp = requests.get(url, auth=self.auth, headers=headers,
-            verify=self.verifySSL)
+            verify=self.verify_ssl)
         if method == "DELETE":
             resp = requests.delete(url, auth=self.auth, headers=headers,
             verify=self.verifySSL)

--- a/pyeti/api.py
+++ b/pyeti/api.py
@@ -12,7 +12,7 @@ import requests
 class YetiApi(object):
     """Python interface to the Yeti REST API."""
 
-    def __init__(self, url, auth=tuple(), api_key=None, verifySSL=True):
+    def __init__(self, url, auth=tuple(), api_key=None, verify_ssl=True):
         super(YetiApi, self).__init__()
         if not url.endswith('/'):
             url += "/"

--- a/pyeti/api.py
+++ b/pyeti/api.py
@@ -351,7 +351,7 @@ class YetiApi(object):
 
         if method == "POST":
             resp = requests.post(url, headers=headers, auth=self.auth,
-            verify=self.verifySSL, **kwargs)
+            verify=self.verify_ssl, **kwargs)
         if method == "GET":
             resp = requests.get(url, auth=self.auth, headers=headers,
             verify=self.verify_ssl)

--- a/pyeti/api.py
+++ b/pyeti/api.py
@@ -357,7 +357,7 @@ class YetiApi(object):
             verify=self.verify_ssl)
         if method == "DELETE":
             resp = requests.delete(url, auth=self.auth, headers=headers,
-            verify=self.verifySSL)
+            verify=self.verify_ssl)
 
         if resp.status_code == 200:
             logging.debug("Success (%s)", resp.status_code)

--- a/pyeti/api.py
+++ b/pyeti/api.py
@@ -12,15 +12,15 @@ import requests
 class YetiApi(object):
     """Python interface to the Yeti REST API."""
 
-    def __init__(self, url, auth=tuple(), api_key=None, verifySSL=False):
+    def __init__(self, url, auth=tuple(), api_key=None, verifySSL=True):
         super(YetiApi, self).__init__()
         if not url.endswith('/'):
             url += "/"
         self.yeti_url = url
         self.auth = auth
         self.api_key = api_key
-        self._test_connection()
         self.verifySSL = verifySSL
+        self._test_connection()
 
     def entity_search(self, count=50, offset=1, regex=False, **kwargs):
         """Fetches a list of indicators associated with an Entity.

--- a/pyeti/api.py
+++ b/pyeti/api.py
@@ -12,7 +12,7 @@ import requests
 class YetiApi(object):
     """Python interface to the Yeti REST API."""
 
-    def __init__(self, url, auth=tuple(), api_key=None):
+    def __init__(self, url, auth=tuple(), api_key=None, verifySSL=False):
         super(YetiApi, self).__init__()
         if not url.endswith('/'):
             url += "/"
@@ -20,6 +20,7 @@ class YetiApi(object):
         self.auth = auth
         self.api_key = api_key
         self._test_connection()
+        self.verifySSL = verifySSL
 
     def entity_search(self, count=50, offset=1, regex=False, **kwargs):
         """Fetches a list of indicators associated with an Entity.
@@ -349,11 +350,14 @@ class YetiApi(object):
             headers.update({"X-Api-Key": self.api_key})
 
         if method == "POST":
-            resp = requests.post(url, headers=headers, auth=self.auth, **kwargs)
+            resp = requests.post(url, headers=headers, auth=self.auth,
+            verify=self.verifySSL, **kwargs)
         if method == "GET":
-            resp = requests.get(url, auth=self.auth, headers=headers)
+            resp = requests.get(url, auth=self.auth, headers=headers,
+            verify=self.verifySSL)
         if method == "DELETE":
-            resp = requests.delete(url, auth=self.auth, headers=headers)
+            resp = requests.delete(url, auth=self.auth, headers=headers,
+            verify=self.verifySSL)
 
         if resp.status_code == 200:
             logging.debug("Success (%s)", resp.status_code)
@@ -362,7 +366,6 @@ class YetiApi(object):
             return resp.content
         else:
             logging.error("An error occurred (%s): %s", resp.status_code, url)
-
 
 if __name__ == '__main__':
     pass

--- a/pyeti/api.py
+++ b/pyeti/api.py
@@ -19,7 +19,7 @@ class YetiApi(object):
         self.yeti_url = url
         self.auth = auth
         self.api_key = api_key
-        self.verifySSL = verifySSL
+        self.verify_ssl = verify_ssl
         self._test_connection()
 
     def entity_search(self, count=50, offset=1, regex=False, **kwargs):

--- a/pyeti/scripts/getfile.py
+++ b/pyeti/scripts/getfile.py
@@ -19,15 +19,15 @@ def run(yeti_api, arguments):
         sys.stdout.flush()
     else:
         tag_names = [t["name"] for t in fileinfo["tags"]]
-        print "File info:"
-        print "{:>15}   {}".format("Added on:", fileinfo["created"])
-        print "{:>15}   {}".format("Filenames:", ", ".join(fileinfo["filenames"]))
-        print "{:>15}   {}".format("Tags:", ", ".join(tag_names))
-        print "{:>15}   {}".format("MIME-type:", fileinfo["mime_type"])
-        print "{:>15}   {}".format("URL:", fileinfo["human_url"])
-        print "\nHashes:"
+        print("File info:")
+        print("{:>15}   {}".format("Added on:", fileinfo["created"]))
+        print("{:>15}   {}".format("Filenames:", ", ".join(fileinfo["filenames"])))
+        print("{:>15}   {}".format("Tags:", ", ".join(tag_names)))
+        print("{:>15}   {}".format("MIME-type:", fileinfo["mime_type"]))
+        print("{:>15}   {}".format("URL:", fileinfo["human_url"]))
+        print("\nHashes:")
         for h in fileinfo['hashes']:
-            print "{:>15}   {}".format(h['hash']+":", h['value'])
+            print("{:>15}   {}".format(h['hash']+":", h['value']))
 
     if arguments.save:
         with open(arguments.save, 'wb') as dumpfile:

--- a/pyeti/scripts/timesketch.py
+++ b/pyeti/scripts/timesketch.py
@@ -6,7 +6,7 @@ def fetch_indicators(yeti_api, entity):
     """Fetches Yeti indicators associated to a given entity."""
     indicators = yeti_api.related_indicators(entity)
     for i in indicators:
-        print i['name']
+        print(i['name'])
 
 def build_timesketch_query_string(indicator):
     """Builds a timesketch query out of a Yeti indicator."""
@@ -22,7 +22,7 @@ def run(yeti_api, arguments):
     """Fetches information on a file in Yeti."""
 
     if not (arguments.id or arguments.name):
-        print "Please specify at least an entity --id or --name."
+        print("Please specify at least an entity --id or --name.")
         exit(-1)
 
     if arguments.id:
@@ -30,19 +30,19 @@ def run(yeti_api, arguments):
     else:
         entities = yeti_api.entity_search(name=arguments.name)
         if len(entities) != 1:
-            print "More than one entity matches your query:"
+            print("More than one entity matches your query:")
             for e in entities:
-                print "  {0:s}: {1:<30s}".format(e['name'], e['id'])
-            print "Rerun the command specifing an --id parameter."
+                print("  {0:s}: {1:<30s}".format(e['name'], e['id']))
+            print("Rerun the command specifing an --id parameter.")
             exit(-1)
         entity = entities[0]
 
     indicators = yeti_api.related_indicators(entity)['data']
-    print "Found {0:d} indicators for entity {1:s} ({2:s})".format(
-        len(indicators), entity['name'], entity['id'])
+    print("Found {0:d} indicators for entity {1:s} ({2:s})".format(
+        len(indicators), entity['name'], entity['id']))
     for i in indicators:
-        print " Name: {0:s}, Pattern: {1:s}".format(
-            i['name'], repr(i['pattern']))
+        print(" Name: {0:s}, Pattern: {1:s}".format(
+            i['name'], repr(i['pattern'])))
 
     c = client.TimesketchApi(
         arguments.endpoint, arguments.username, arguments.password)
@@ -52,14 +52,14 @@ def run(yeti_api, arguments):
         response = sketch.explore(query_string=query_string)
         events = response['objects']
         if events:
-            print "[!] Found {0:d} matching events for {1:s}".format(
-                len(events), i['name'])
+            print("[!] Found {0:d} matching events for {1:s}".format(
+                len(events), i['name']))
             for e in events:
                 timestamp = e['_source']['datetime']
                 description = e['_source']['timestamp_desc']
                 message = e['_source']['message']
                 labels = e['_source']['label']
-                print "{0:s} {1:<30s} {2:s} {3:s}".format(
-                    timestamp, description, message, labels)
+                print("{0:s} {1:<30s} {2:s} {3:s}".format(
+                    timestamp, description, message, labels))
             if arguments.tag:
                 sketch.label_events(events, "yeti")

--- a/tests/test.py
+++ b/tests/test.py
@@ -40,7 +40,7 @@ class TestAPI(TestCase):
 
     def test_YetiApi_with_url_ignore_ssl(self):
         try:
-            self.test = pyeti.YetiApi('http://localhost:5000', verifySSL=False)
+            self.test = pyeti.YetiApi('http://localhost:5000', verify_ssl=False)
         except TypeError as e:
             pass  # fail appropriately here.
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -16,7 +16,7 @@ class TestAPI(TestCase):
 
         httpd = SocketServer.TCPServer(("", PORT), Handler)
 
-        print "serving at port", PORT
+        print("serving at port", PORT)
         httpd.serve_forever()
 
     def test_have_class(self):
@@ -35,6 +35,12 @@ class TestAPI(TestCase):
     def test_YetiApi_with_url(self):
         try:
             self.test = pyeti.YetiApi('http://localhost:5000')
+        except TypeError as e:
+            pass  # fail appropriately here.
+
+    def test_YetiApi_with_url_ignore_ssl(self):
+        try:
+            self.test = pyeti.YetiApi('http://localhost:5000', verifySSL=False)
         except TypeError as e:
             pass  # fail appropriately here.
 


### PR DESCRIPTION
Not much needed to make python3 supported. I also added the ability to over ride the ssl check in the client. This was breaking things when trying to use pyeti with any server using a self signed cert. By default verification is set to true, which will not break backwards compatibility. If you think this is something we shouldn't support I can remove it and just keep it in my fork. 